### PR TITLE
Change import Veriff as named import

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ or install it via a package manager
   const Veriff = require('@veriff/js-sdk');
 
   // ES6 style import
-  import Veriff from '@veriff/js-sdk';
+  import {Veriff} from '@veriff/js-sdk';
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ or install it via a package manager
   const Veriff = require('@veriff/js-sdk');
 
   // ES6 style import
-  import {Veriff} from '@veriff/js-sdk';
+  import { Veriff } from '@veriff/js-sdk';
 
 ```
 


### PR DESCRIPTION

I tried to import Veriff as default in ES6 style but it didn't work , It seems it is not exported as default , but in document it is imported as default , so I changed as named export and it worked well.