### PR TITLE
fix: input border color on focus state bug fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veriff/js-sdk",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "JavaScript SDK for Veriff identity verification",
   "main": "lib/veriff.js",
   "types": "lib/index.d.ts",

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -46,7 +46,7 @@
 
 .veriff-text:focus {
   box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.1), 0px 0px 0px 1px rgba(0, 78, 95, 0.46),
-    0px 0px 0px 4px var(--genoma-colors-borderBrandHighlight);
+    0px 0px 0px 4px rgba(212, 250, 237, 1);
 }
 
 .veriff-submit {


### PR DESCRIPTION
We are using the genoma token for the color on the focus state of the inputs. It should be changed to a color code.